### PR TITLE
Import aqt.tooltip to avoid NameError

### DIFF
--- a/addons/cardheatmap/cardheatmap.py
+++ b/addons/cardheatmap/cardheatmap.py
@@ -10,6 +10,7 @@ import time
 import aqt
 from aqt.qt import *
 from aqt import mw
+from aqt.utils import tooltip
 
 from anki.stats import CollectionStats
 from anki.hooks import wrap, addHook


### PR DESCRIPTION
Just a quick fix for an error I ran into when testing the add-on on an empty Anki profile.